### PR TITLE
Event association

### DIFF
--- a/subatomic_coherence/slack_test_suite.py
+++ b/subatomic_coherence/slack_test_suite.py
@@ -64,7 +64,7 @@ class SlackTestSuite(object):
         for slack_user in self.slack_user_workspace.slack_user_clients:
             events = slack_user.client.rtm_read()
             for event in events:
-                slack_user.events.append(event)
+                slack_user.load_events(event)
                 logging.info("User {user} received event {event}"
                              .format(user=slack_user.username, event=json.dumps(event)))
                 if event["type"] == "channel_created":
@@ -108,7 +108,7 @@ class SlackTestSuite(object):
 
     def _clear_event_stores(self):
         for slack_user in self.slack_user_workspace.slack_user_clients:
-            slack_user.events = []
+            slack_user.clear_event_store()
 
     def _configure_workspace(self):
         self.slack_user_workspace.set_workspace_user_details(

--- a/subatomic_coherence/user/slack_user_workspace.py
+++ b/subatomic_coherence/user/slack_user_workspace.py
@@ -76,3 +76,10 @@ class SlackUserWorkspace(object):
         if result is None:
             result = self.find_group_by_slack_id(slack_id)
         return result
+
+    def last_processed_event(self):
+        for user in self.slack_user_clients:
+            user_last_event = user.events.last_processed_event
+            if user_last_event is not None:
+                return user_last_event
+        return None

--- a/testing/tests/actions/test_simple_actions.py
+++ b/testing/tests/actions/test_simple_actions.py
@@ -20,12 +20,12 @@ def test_expect_message_with_simple_message_from_user_expect_event_returned():
         "user": "U2222222",
         "text": "some text"
     }
-    user.events = [
+    user.load_events([
         expected_event,
         {
             "type": "not_a_message"
         }
-    ]
+    ])
 
     result = SimpleActions._expect_message(user, "U2222222")
     assert result["type"] == "message"
@@ -42,12 +42,12 @@ def test_expect_message_with_subtype_message_from_user_expect_event_returned():
             "text": "some text"
         }
     }
-    user.events = [
+    user.load_events([
         expected_event,
         {
             "type": "not_a_message"
         }
-    ]
+    ])
 
     result = SimpleActions._expect_message(user, "U2222222")
     assert result == expected_event
@@ -61,12 +61,12 @@ def test_expect_message_threaded_message_from_user_expect_event_returned():
         "text": "some text",
         "thread_ts": "1000"
     }
-    user.events = [
+    user.load_events([
         expected_event,
         {
             "type": "not_a_message"
         }
-    ]
+    ])
 
     result = SimpleActions._expect_message(user, "U2222222", is_thread=True)
     assert result == expected_event
@@ -80,7 +80,7 @@ def test_expect_message_thread_message_with_ts_from_user_expect_event_returned()
         "text": "some text",
         "thread_ts": "1000"
     }
-    user.events = [
+    user.load_events([
         expected_event,
         {
             "type": "message",
@@ -88,7 +88,7 @@ def test_expect_message_thread_message_with_ts_from_user_expect_event_returned()
             "text": "some text",
             "thread_ts": "1002"
         }
-    ]
+    ])
 
     result = SimpleActions._expect_message(user, "U2222222", is_thread=True, thread_ts="1000")
     assert result["thread_ts"] == "1000"
@@ -103,7 +103,7 @@ def test_expect_message_with_simple_message_from_channel_expect_event_returned()
         "text": "some text",
         "channel": "G111111"
     }
-    user.events = [
+    user.load_events([
         expected_event,
         {
             "type": "message",
@@ -111,7 +111,7 @@ def test_expect_message_with_simple_message_from_channel_expect_event_returned()
             "text": "some text",
             "channel": "G111112"
         }
-    ]
+    ])
 
     result = SimpleActions._expect_message(user, "U2222222", channel_id="G111111")
     assert result["channel"] == "G111111"
@@ -125,14 +125,14 @@ def test_expect_message_with_matching_text_from_user_ignore_case_expect_event_re
         "user": "U2222222",
         "text": "some text"
     }
-    user.events = [
+    user.load_events([
         expected_event,
         {
             "type": "message",
             "user": "U2222222",
             "text": "some text that is wrong"
         }
-    ]
+    ])
 
     result = SimpleActions._expect_message(user, "U2222222", message_text="SOME TEXT")
     assert result == expected_event
@@ -145,14 +145,14 @@ def test_expect_message_with_matching_text_from_user_case_sensitive_expect_event
         "user": "U2222222",
         "text": "SOME TEXT"
     }
-    user.events = [
+    user.load_events([
         expected_event,
         {
             "type": "message",
             "user": "U2222222",
             "text": "some text"
         }
-    ]
+    ])
 
     result = SimpleActions._expect_message(user, "U2222222", message_text="SOME TEXT", ignore_case=False)
     assert result == expected_event
@@ -511,7 +511,7 @@ def test_expect_channel_created_expect_success():
                 "name": "channel1"
             }
     }
-    user1.events += [event]
+    user1.events.load_event(event)
     result = channel_created_function(slack_user_workspace, {})
     assert result.result_code == ResultCode.success
 
@@ -529,7 +529,7 @@ def test_expect_channel_created_expect_pending_result():
                 "name": "channel2"
             }
     }
-    user1.events += [event]
+    user1.load_events(event)
     result = channel_created_function(slack_user_workspace, {})
     assert result.result_code == ResultCode.pending
 

--- a/testing/tests/test_slack_test_suite.py
+++ b/testing/tests/test_slack_test_suite.py
@@ -49,7 +49,7 @@ def test_client_read_event_expect_events_added_to_event_store_of_client():
     user.client.rtm_read = MagicMock(return_value=[event])
     test_suite._read_slack_events()
     assert test_suite.new_events is True
-    assert user.events[-1] == event
+    assert user.events.events[-1] == event
 
 
 def test_client_read_channel_created_event_expect_channel_details_added_to_slack_workspace():

--- a/testing/tests/testing/test_test.py
+++ b/testing/tests/testing/test_test.py
@@ -1,6 +1,7 @@
 import time
 
-from subatomic_coherence.testing.test import TestPortal, ResultCode, TestResult, TestElement
+from subatomic_coherence.testing.test import TestPortal, ResultCode, TestResult, TestElement, CallStackAction
+from subatomic_coherence.user.slack_user_workspace import SlackUserWorkspace
 
 
 def test_test_portal_test_simple_expect_success():
@@ -23,10 +24,11 @@ def test_test_portal_test_simple_expect_failure():
 
 def test_test_portal_test_with_child_expect_failure():
     test = TestPortal().then(lambda slack_user_workspace, data_store: TestResult(ResultCode.failure, "FAILURE"))
-    result = test.test([])
+    user_workspace = SlackUserWorkspace()
+    result = test.test(user_workspace)
     assert result.result_code == ResultCode.pending
     assert test.is_live is True
-    result = test.test([])
+    result = test.test(user_workspace)
     assert result.result_code == ResultCode.failure
     assert result.result == "failure"
     assert result.message == "FAILURE"
@@ -36,10 +38,11 @@ def test_test_portal_test_with_child_expect_failure():
 def test_test_portal_test_timeout_expect_failure():
     test = TestPortal(timeout=10)
     test.run_element = lambda slack_user_workspace, data_store: TestResult(ResultCode.pending)
-    result = test.test([])
+    user_workspace = SlackUserWorkspace()
+    result = test.test(user_workspace)
     assert result.result_code == ResultCode.pending
     time.sleep(0.015)
-    result = test.test([])
+    result = test.test(user_workspace)
     assert result.result_code == ResultCode.failure
     assert test.is_live is False
     assert result.message.startswith("Time out occurred when calling") is True
@@ -70,13 +73,14 @@ def test_test_portal_data_store_expect_data_persisted_between_steps():
 
     test = TestPortal()
     test.then(mock_action1).then(mock_action2)
+    user_workspace = SlackUserWorkspace()
     # Run TestPortal initial run element
-    test.test([])
+    test.test(user_workspace)
     # Run mock_action_1
-    test.test([])
+    test.test(user_workspace)
     assert test.data_store["action1"] == "value1"
     # Run mock_action_2
-    test.test([])
+    test.test(user_workspace)
     assert test.data_store["action1"] == "value1"
     assert test.data_store["action2"] == "value2"
 
@@ -91,12 +95,13 @@ def test_test_portal_failed_test_call_stack_expect_correct_call_stack():
     test = TestPortal()
     test.then(mock_action1).then(mock_action2)
     test.name = "portal"
+    user_workspace = SlackUserWorkspace()
     # Run TestPortal initial run element
-    test.test([])
+    test.test(user_workspace)
     # Run mock_action_1
-    test.test([])
+    test.test(user_workspace)
     # Run mock_action_2
-    result = test.test([])
+    result = test.test(user_workspace)
     assert result.call_stack == "portal\n.then(mock_action1)\n.then(mock_action2)"
 
 
@@ -118,8 +123,8 @@ def test_test_portal_failed_test_with_runtime_error_expect_failed_test_result():
 def test_test_portal_build_simple_stack_message_expect_correct_stack_message():
     test = TestPortal()
     test.name = "portal"
-    test.simple_call_stack += ["mock1"]
-    test.simple_call_stack += ["mock2"]
+    test.simple_call_stack += [CallStackAction("mock1")]
+    test.simple_call_stack += [CallStackAction("mock2")]
     result = test._build_simple_stack_message()
     assert result == "portal\n.then(mock1)\n.then(mock2)"
 
@@ -130,4 +135,4 @@ def test_test_portal_push_action_onto_stack_expect_correct_function_name_pushed_
 
     test = TestPortal().then(some_function)
     test._push_action_onto_stack(test.current_action.next_action)
-    assert test.simple_call_stack[0] == "some_function"
+    assert test.simple_call_stack[0].name == "some_function"

--- a/testing/tests/user/test_slack_user.py
+++ b/testing/tests/user/test_slack_user.py
@@ -1,7 +1,7 @@
 from unittest import mock
 from unittest.mock import MagicMock
 
-from subatomic_coherence.user.slack_user import SlackUser, RateLimiter
+from subatomic_coherence.user.slack_user import SlackUser, RateLimiter, EventStore
 from testing.mocking.mocking import MockRequestsResponse
 
 
@@ -232,3 +232,29 @@ def test_rate_limiter_where_exceeding_count_expect_wait_time_correct():
     limiter.current_milli_time = lambda: 5
     assert limiter.can_call() is False
     assert limiter.wait_time() == 5
+
+
+def test_event_store_load_event_expect_success():
+    event_store = EventStore()
+    event_store.load_event({"id": 5})
+    assert event_store.events[0]["id"] == 5
+
+
+def test_event_store_clear_event_store_expect_success():
+    event_store = EventStore()
+    event_store.load_event({"id": 5})
+    event_store.__next__()
+    event_store.clear_event_store()
+    assert len(event_store.events) == 0
+    assert event_store.next_event_index == 0
+    assert event_store.last_processed_event is None
+
+
+def test_event_store_iter_expect_success():
+    event_store = EventStore()
+    event_store.load_event({"id": 5})
+    for event in event_store:
+        assert event["id"] == 5
+
+    assert event_store.last_processed_event is None
+    assert event_store.next_event_index == 1


### PR DESCRIPTION
Events that are used to successfully pass a test action are now printed in failed test logs for improved debugging.

Resolves #31 