### PR TITLE
Expect event functionality

### DIFF
--- a/subatomic_coherence/actions/event_actions.py
+++ b/subatomic_coherence/actions/event_actions.py
@@ -1,0 +1,54 @@
+class EventVerifier(object):
+    def __init__(self, event_template):
+        self.event_template = event_template
+        self.stored_values = {}
+
+    def verify(self, event):
+        self.stored_values = {}
+        return self.verify_property(self.event_template, event)
+
+    def verify_dict_property(self, base_property, event_property, property_name):
+        if isinstance(event_property, dict) and property_name in event_property:
+            return self.verify_property(base_property[property_name], event_property[property_name])
+        return False
+
+    def verify_list_property(self, base_property, event_property):
+        verified = False
+        if isinstance(event_property, list):
+            for event_entry in event_property:
+                verified |= self.verify_property(base_property, event_entry)
+        return verified
+
+    def verify_property(self, base_property, event_property):
+        if isinstance(base_property, dict):
+            verified = True
+            for sub_property in base_property:
+                verified &= self.verify_dict_property(base_property, event_property, sub_property)
+            return verified
+        elif isinstance(base_property, list):
+            verified = True
+            for base_entry in base_property:
+                verified &= self.verify_list_property(base_entry, event_property)
+            return verified
+        else:
+            cleaned_base_property = self.clean_value(base_property)
+            if cleaned_base_property == "*":
+                result = True
+            else:
+                result = cleaned_base_property == event_property
+            if result:
+                self.try_store_requested_value(base_property, event_property)
+            return result
+
+    def try_store_requested_value(self, base_property, event_value):
+        if base_property.startswith("{{") and base_property.endswith("}}"):
+            name = base_property[2: base_property.index(",")]
+            self.stored_values[name] = event_value
+
+    def clean_value(self, value):
+        if value.startswith("\\"):
+            return value[1:]
+        if value.startswith("{{") and value.endswith("}}"):
+            return value[value.index(",") + 1:-2]
+
+        return value

--- a/subatomic_coherence/actions/event_actions.py
+++ b/subatomic_coherence/actions/event_actions.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from subatomic_coherence.testing.test import TestResult, ResultCode
 
 
@@ -17,34 +19,44 @@ class EventVerifier(object):
     def __init__(self, event_template):
         self.event_template = event_template
         self.stored_values = {}
+        self.event_pattern_context = EventPatternContext()
+        self.parse_template(self.event_template)
 
     def verify(self, event):
         self.stored_values = {}
         return self.verify_property(self.event_template, event)
 
-    def verify_dict_property(self, base_property, event_property, property_name):
+    def verify_dict_property(self, base_property, event_property, property_name, depth):
+        self.event_pattern_context.reset_groups(depth)
         if isinstance(event_property, dict) and property_name in event_property:
-            return self.verify_property(base_property[property_name], event_property[property_name])
+            return self.verify_property(base_property[property_name], event_property[property_name], depth + 1)
         return False
 
-    def verify_list_property(self, base_property, event_property):
+    def verify_list_property(self, base_property, event_property, depth):
+        self.event_pattern_context.reset_groups(depth)
         verified = False
         if isinstance(event_property, list):
             for event_entry in event_property:
-                verified |= self.verify_property(base_property, event_entry)
+                verified |= self.verify_property(base_property, event_entry, depth + 1)
         return verified
 
-    def verify_property(self, base_property, event_property):
+    def verify_property(self, base_property, event_property, depth=0):
+        self.event_pattern_context.reset_groups(depth)
         if isinstance(base_property, dict):
             verified = True
             for sub_property in base_property:
-                verified &= self.verify_dict_property(base_property, event_property, sub_property)
+                verified &= self.verify_dict_property(base_property, event_property, sub_property, depth + 1)
             return verified
         elif isinstance(base_property, list):
             verified = True
             for base_entry in base_property:
-                verified &= self.verify_list_property(base_entry, event_property)
+                verified &= self.verify_list_property(base_entry, event_property, depth + 1)
             return verified
+        elif isinstance(base_property, EventPattern):
+            if base_property.match(event_property):
+                self.event_pattern_context.store_result(base_property, self.stored_values)
+                return True
+            return False
         else:
             cleaned_base_property = self.clean_value(base_property)
             if cleaned_base_property == "*":
@@ -67,3 +79,120 @@ class EventVerifier(object):
             return value[value.index(",") + 1:-2]
 
         return value
+
+    def parse_template(self, next_property, property_stack=None):
+        if property_stack is None:
+            property_stack = ["base"]
+        if isinstance(next_property, dict):
+            for sub_property in next_property:
+                self.parse_template(next_property[sub_property], property_stack + [sub_property])
+        elif isinstance(next_property, list):
+            for entry in next_property:
+                self.parse_template(entry, property_stack + [property_stack[-1] + "[]"])
+        elif isinstance(next_property, EventPattern):
+            next_property.property_stack = property_stack
+            self.event_pattern_context.add_event_pattern(next_property)
+
+
+class EventPatternContext(object):
+    def __init__(self):
+        self.event_pattern_groups = {}
+        self.event_patterns = []
+
+    def add_event_pattern(self, event_pattern):
+        self.event_patterns += [event_pattern]
+        if event_pattern.group_id is not None:
+            if event_pattern.group_id not in self.event_pattern_groups:
+                self.event_pattern_groups[event_pattern.group_id] = EventPatternGroup(event_pattern.group_id)
+
+            self.event_pattern_groups[event_pattern.group_id].add_event_pattern(event_pattern)
+
+    def reset_groups(self, depth):
+        for key in self.event_pattern_groups:
+            self.event_pattern_groups[key].reset_if_necessary(depth)
+
+    def store_result(self, event_pattern, value_store):
+        if event_pattern.group_id in self.event_pattern_groups:
+            self.event_pattern_groups[event_pattern.group_id].store_values(value_store)
+        else:
+            event_pattern.store_value(value_store)
+
+
+class EventPatternGroup(object):
+    def __init__(self, group_id):
+        self.group_id = group_id
+        self.event_patterns = []
+        self.reset_depth = 0
+
+    def add_event_pattern(self, event_pattern):
+        self.event_patterns += [event_pattern]
+
+    def calculate_depth(self):
+        reference_property_stack = self.event_patterns[0].property_stack
+        for property_index in range(0, len(reference_property_stack)):
+            for pattern in self.event_patterns:
+                if len(pattern.property_stack) <= property_index or not pattern.property_stack[property_index] == \
+                        reference_property_stack[property_index]:
+                    self.reset_depth = property_index - 1
+                    return
+
+        self.reset_depth = -1
+
+    def reset_if_necessary(self, depth):
+        if depth == self.reset_depth:
+            for event_pattern in self.event_patterns:
+                event_pattern.matched = False
+
+    def is_fully_matched(self):
+        fully_matched = True
+        for pattern in self.event_patterns:
+            if not pattern.matched:
+                fully_matched = False
+                break
+        return fully_matched
+
+    def store_values(self, value_store):
+        if self.is_fully_matched():
+            for pattern in self.event_patterns:
+                pattern.store_value(value_store)
+
+
+class EventPattern(object):
+    def __init__(self, storage_name=None, group_id=None):
+        self.group_id = group_id
+        self.matched = False
+        self.matched_value = None
+        self.storage_name = storage_name
+        self.property_stack = []
+
+    def match(self, value):
+        if self.match_implementation(value):
+            self.matched = True
+            self.matched_value = value
+        else:
+            self.matched = False
+        return self.matched
+
+    def match_implementation(self, value):
+        return NotImplementedError()
+
+    def store_value(self, value_store):
+        if self.storage_name is not None and self.matched:
+            value_store[self.storage_name] = self.matched_value
+
+
+class WildCardEventPattern(EventPattern):
+    def __init__(self, storage_name=None, group_id=None):
+        super().__init__(storage_name, group_id)
+
+    def match_implementation(self, value):
+        return True
+
+
+class SimpleEventPattern(EventPattern):
+    def __init__(self, expected_value, storage_name=None, group_id=None):
+        super().__init__(storage_name, group_id)
+        self.expected_value = expected_value
+
+    def match_implementation(self, value):
+        return self.expected_value == value

--- a/subatomic_coherence/actions/event_actions.py
+++ b/subatomic_coherence/actions/event_actions.py
@@ -126,6 +126,7 @@ class EventPatternGroup(object):
 
     def add_event_pattern(self, event_pattern):
         self.event_patterns += [event_pattern]
+        self.calculate_depth()
 
     def calculate_depth(self):
         reference_property_stack = self.event_patterns[0].property_stack
@@ -166,11 +167,13 @@ class EventPattern(object):
         self.property_stack = []
 
     def match(self, value):
-        if self.match_implementation(value):
+        matched_value = self.match_implementation(value)
+        if matched_value:
             self.matched = True
             self.matched_value = value
-        else:
+        elif self.group_id is None:
             self.matched = False
+        # dont set matched to false for groups unless reset is called
         return self.matched
 
     def match_implementation(self, value):

--- a/subatomic_coherence/actions/event_actions.py
+++ b/subatomic_coherence/actions/event_actions.py
@@ -7,6 +7,8 @@ def expect_event(user, event_template):
         event_verifier = EventVerifier(event_template)
         for event in user_client.events:
             if event_verifier.verify(event):
+                for key in event_verifier.stored_values:
+                    data_store[key] = event_verifier.stored_values[key]
                 return TestResult(ResultCode.success)
         return TestResult(ResultCode.pending)
 

--- a/subatomic_coherence/actions/event_actions.py
+++ b/subatomic_coherence/actions/event_actions.py
@@ -1,3 +1,18 @@
+from subatomic_coherence.testing.test import TestResult, ResultCode
+
+
+def expect_event(user, event_template):
+    def expect_event_function(slack_user_workspace, data_store):
+        user_client = slack_user_workspace.find_user_client_by_username(user)
+        event_verifier = EventVerifier(event_template)
+        for event in user_client.events:
+            if event_verifier.verify(event):
+                return TestResult(ResultCode.success)
+        return TestResult(ResultCode.pending)
+
+    return expect_event_function
+
+
 class EventVerifier(object):
     def __init__(self, event_template):
         self.event_template = event_template

--- a/subatomic_coherence/actions/simple_actions.py
+++ b/subatomic_coherence/actions/simple_actions.py
@@ -166,6 +166,38 @@ def expect_and_store_action_message(from_user_slack_name,
     return expect_and_store_action_message_function
 
 
+def respond_to_custom_stored_action_message(from_user_slack_name,
+                                            service_id_key="service_id",
+                                            bot_user_id_key="bot_user_id",
+                                            attachment_id_key="attachment_id",
+                                            action_key="action",
+                                            call_back_id_key="callback_id",
+                                            channel_key="channel",
+                                            ts_key="ts"):
+    def respond_to_custom_stored_action_message_function(slack_user_workspace, data_store):
+        user_sender = slack_user_workspace.find_user_client_by_username(from_user_slack_name)
+        service_id = data_store[service_id_key]
+        bot_user_id = data_store[bot_user_id_key]
+        attachment_id = data_store[attachment_id_key]
+        action = data_store[action_key]
+        call_back_id = data_store[call_back_id_key]
+        channel = data_store[channel_key]
+        ts = data_store[ts_key]
+        result, response = user_sender.attachment_action(service_id,
+                                                         bot_user_id,
+                                                         [action],
+                                                         attachment_id,
+                                                         call_back_id,
+                                                         channel,
+                                                         ts)
+        if result:
+            return TestResult(ResultCode.success)
+        else:
+            return TestResult(ResultCode.failure, response.content)
+
+    return respond_to_custom_stored_action_message_function
+
+
 def respond_to_stored_action_message(from_user_slack_name,
                                      event_storage_name,
                                      attachment_ids=None,

--- a/testing/tests/actions/test_event_actions.py
+++ b/testing/tests/actions/test_event_actions.py
@@ -1,0 +1,518 @@
+from subatomic_coherence.actions.event_actions import WildCardEventPattern, SimpleEventPattern, EventPatternGroup, \
+    EventPatternContext, EventVerifier
+
+
+def test_wild_card_event_pattern_expect_match():
+    event_pattern = WildCardEventPattern()
+
+    event_pattern.match("Whatever")
+
+    assert event_pattern.matched is True
+    assert event_pattern.matched_value == "Whatever"
+
+
+def test_wild_card_event_pattern_expect_matched_value_stored():
+    event_pattern = WildCardEventPattern(storage_name="VAL")
+    store = {}
+
+    event_pattern.match("Whatever")
+    event_pattern.store_value(store)
+
+    assert event_pattern.matched is True
+    assert store["VAL"] == "Whatever"
+
+
+def test_simple_event_pattern_expect_match():
+    event_pattern = SimpleEventPattern("Some value")
+    event_pattern.match("Some value")
+
+    assert event_pattern.matched is True
+    assert event_pattern.matched_value == "Some value"
+
+
+def test_simple_event_pattern_expect_not_matched():
+    event_pattern = SimpleEventPattern("Some value")
+    event_pattern.match("Some value 2")
+
+    assert event_pattern.matched is False
+
+
+def test_simple_event_pattern_expect_value_stored():
+    event_pattern = SimpleEventPattern("Some value")
+    store = {}
+    event_pattern.match("Some value")
+    event_pattern.store_value(store)
+
+    assert event_pattern.matched is True
+    assert event_pattern.matched_value == "Some value"
+
+
+def test_event_group_expect_group_created():
+    group = EventPatternGroup(1)
+    pat1 = SimpleEventPattern("1", group_id=1)
+    pat1.property_stack = ["base", "base{}", "1"]
+    pat2 = SimpleEventPattern("2", group_id=1)
+    pat2.property_stack = ["base", "base{}", "3", "something"]
+    group.add_event_pattern(pat1)
+    group.add_event_pattern(pat2)
+
+    assert pat1 in group.event_patterns
+    assert pat2 in group.event_patterns
+
+    assert group.reset_depth == 1
+
+
+def test_event_group_expect_group_matched():
+    group = EventPatternGroup(1)
+    pat1 = SimpleEventPattern("1", group_id=1)
+    pat1.property_stack = ["base"]
+    pat2 = SimpleEventPattern("2", group_id=1)
+    pat2.property_stack = ["base"]
+    group.add_event_pattern(pat1)
+    group.add_event_pattern(pat2)
+    pat1.match("1")
+    pat2.match("2")
+
+    assert group.is_fully_matched()
+
+
+def test_event_group_expect_group_not_matched():
+    group = EventPatternGroup(1)
+    pat1 = SimpleEventPattern("1", group_id=1)
+    pat1.property_stack = ["base"]
+    pat2 = SimpleEventPattern("2", group_id=1)
+    pat2.property_stack = ["base"]
+    group.add_event_pattern(pat1)
+    group.add_event_pattern(pat2)
+    pat1.match("1")
+
+    assert not group.is_fully_matched()
+
+
+def test_event_group_expect_reset():
+    group = EventPatternGroup(1)
+    pat1 = SimpleEventPattern("1", group_id=1)
+    pat1.property_stack = ["base", "base{}", "1"]
+    pat2 = SimpleEventPattern("2", group_id=1)
+    pat2.property_stack = ["base", "base{}", "3", "something"]
+    group.add_event_pattern(pat1)
+    group.add_event_pattern(pat2)
+    pat1.match("1")
+
+    group.reset_if_necessary(1)
+
+    assert not pat1.matched
+
+
+def test_event_group_expect_not_reset():
+    group = EventPatternGroup(1)
+    pat1 = SimpleEventPattern("1", group_id=1)
+    pat1.property_stack = ["base", "base{}", "1"]
+    pat2 = SimpleEventPattern("2", group_id=1)
+    pat2.property_stack = ["base", "base{}", "3", "something"]
+    group.add_event_pattern(pat1)
+    group.add_event_pattern(pat2)
+    pat1.match("1")
+
+    group.reset_if_necessary(2)
+
+    assert pat1.matched
+
+
+def test_event_group_expect_stored_values():
+    group = EventPatternGroup(1)
+    pat1 = SimpleEventPattern("1", group_id=1, storage_name="VAL")
+    pat1.property_stack = ["base"]
+    pat2 = SimpleEventPattern("2", group_id=1)
+    pat2.property_stack = ["base"]
+    group.add_event_pattern(pat1)
+    group.add_event_pattern(pat2)
+    pat1.match("1")
+    pat2.match("2")
+
+    store = {}
+
+    group.store_values(store)
+
+    assert store["VAL"] == "1"
+
+
+def test_event_group_expect_no_stored_values():
+    group = EventPatternGroup(1)
+    pat1 = SimpleEventPattern("1", group_id=1, storage_name="VAL")
+    pat1.property_stack = ["base"]
+    pat2 = SimpleEventPattern("2", group_id=1)
+    pat2.property_stack = ["base"]
+    group.add_event_pattern(pat1)
+    group.add_event_pattern(pat2)
+    pat1.match("1")
+
+    store = {}
+
+    group.store_values(store)
+
+    assert "VAL" not in store
+
+
+def test_event_context_expect_group_created():
+    event_context = EventPatternContext()
+    pat1 = SimpleEventPattern("1", group_id=1)
+    pat1.property_stack = ["base"]
+    pat2 = SimpleEventPattern("2", group_id=1)
+    pat2.property_stack = ["base"]
+    event_context.add_event_pattern(pat1)
+    event_context.add_event_pattern(pat2)
+
+    assert event_context.event_pattern_groups[1] is not None
+
+
+def test_event_context_expect_group_not_created():
+    event_context = EventPatternContext()
+    pat1 = SimpleEventPattern("1", group_id=None)
+    pat1.property_stack = ["base"]
+    pat2 = SimpleEventPattern("2", group_id=None)
+    pat2.property_stack = ["base"]
+    event_context.add_event_pattern(pat1)
+    event_context.add_event_pattern(pat2)
+
+    assert len(event_context.event_pattern_groups.keys()) == 0
+
+
+def test_event_context_expect_necessary_results_stored():
+    event_context = EventPatternContext()
+    pat1 = SimpleEventPattern("1", group_id=1, storage_name="VAL")
+    pat1.property_stack = ["base"]
+    pat2 = SimpleEventPattern("2", group_id=1)
+    pat2.property_stack = ["base"]
+    pat3 = SimpleEventPattern("3", group_id=2, storage_name="VAL2")
+    pat3.property_stack = ["base"]
+    pat4 = SimpleEventPattern("4", group_id=2)
+    pat4.property_stack = ["base"]
+    event_context.add_event_pattern(pat1)
+    event_context.add_event_pattern(pat2)
+    event_context.add_event_pattern(pat3)
+    event_context.add_event_pattern(pat4)
+    pat1.match("1")
+    pat3.match("3")
+    pat4.match("4")
+
+    store = {}
+
+    event_context.store_result(pat1, store)
+    event_context.store_result(pat4, store)
+
+    assert store["VAL2"] == "3"
+    assert "VAL" not in store
+
+
+def test_event_context_expect_group_reset():
+    event_context = EventPatternContext()
+    pat1 = SimpleEventPattern("1", group_id=1)
+    pat1.property_stack = ["base"]
+    pat2 = SimpleEventPattern("2", group_id=1)
+    pat2.property_stack = ["base"]
+    event_context.add_event_pattern(pat1)
+    event_context.add_event_pattern(pat2)
+    pat1.match("1")
+
+    event_context.reset_groups(-1)
+
+    assert not pat1.matched
+
+
+def test_event_verifier_expect_double_slash_value_cleaned():
+    verifier = EventVerifier({})
+    result = verifier.clean_value("\\\\Something")
+    assert result == "\\Something"
+
+
+def test_event_verifier_expect_bracketed_value_cleaned():
+    verifier = EventVerifier({})
+    result = verifier.clean_value("{{name,value}}")
+    assert result == "value"
+
+
+def test_event_verifier_expect_normal_value_not_cleaned():
+    verifier = EventVerifier({})
+    result = verifier.clean_value("value")
+    assert result == "value"
+
+
+def test_event_verifier_expect_template_parsed():
+    verifier = EventVerifier({
+        "name": "Kieran",
+        "store": "{{store,*}}",
+        "list": [
+            {
+                "3": "*",
+                "4": "{{FOUR,*}}",
+                "5": SimpleEventPattern("This value", "Value2", 1),
+                "6": SimpleEventPattern("2", "Value2", 1)
+            },
+            {
+                "6": SimpleEventPattern("3", "Value5")
+            }
+        ],
+        "event_pattern": WildCardEventPattern("Value", 1)
+    })
+
+    assert verifier.event_pattern_context.event_pattern_groups[1] is not None
+    assert verifier.event_pattern_context.event_pattern_groups[1].reset_depth == 0
+    assert len(verifier.event_pattern_context.event_patterns) == 4
+
+
+def test_event_verifier_expect_built_in_match_and_store():
+    verifier = EventVerifier({
+        "name": "Kieran",
+        "store": "{{store,*}}",
+        "dont_store": "*"
+    })
+
+    result = verifier.verify({
+        "name": "Kieran",
+        "store": "1",
+        "dont_store": "something"
+    })
+
+    assert result
+    assert verifier.stored_values["store"] == "1"
+
+
+def test_event_verifier_expect_event_pattern_match_and_store():
+    verifier = EventVerifier({
+        "name": SimpleEventPattern("Kieran"),
+        "store": WildCardEventPattern("store"),
+        "dont_store": WildCardEventPattern()
+    })
+
+    result = verifier.verify({
+        "name": "Kieran",
+        "store": "1",
+        "dont_store": "something"
+    })
+
+    assert result
+    assert verifier.stored_values["store"] == "1"
+
+
+def test_event_verifier_expect_simple_match_failed():
+    verifier = EventVerifier({
+        "name": "Kieran",
+        "store": "{{store,*}}",
+        "dont_store": "*"
+    })
+
+    result = verifier.verify({
+        "name": "Kieran",
+        "store": "1",
+    })
+
+    assert not result
+
+
+def test_event_verifier_expect_event_pattern_match_list():
+    verifier = EventVerifier({
+        "name": SimpleEventPattern("Kieran"),
+        "list": [
+            SimpleEventPattern("1")
+        ],
+    })
+
+    result = verifier.verify({
+        "name": "Kieran",
+        "list": [
+            "1",
+            "2"
+        ]
+    })
+
+    assert result
+
+
+def test_event_verifier_expect_event_pattern_match_list_failed():
+    verifier = EventVerifier({
+        "name": SimpleEventPattern("Kieran"),
+        "list": [
+            SimpleEventPattern("1")
+        ],
+    })
+
+    result = verifier.verify({
+        "name": "Kieran",
+        "list": [
+            "2"
+        ]
+    })
+
+    assert not result
+
+
+def test_event_verifier_expect_event_pattern_match_dict():
+    verifier = EventVerifier({
+        "name": SimpleEventPattern("Kieran"),
+        "dict": {
+            "child": SimpleEventPattern("1")
+        },
+    })
+
+    result = verifier.verify({
+        "name": "Kieran",
+        "dict": {
+            "child": "1"
+        }
+    })
+
+    assert result
+
+
+def test_event_verifier_expect_event_pattern_match_dict_failed():
+    verifier = EventVerifier({
+        "name": SimpleEventPattern("Kieran"),
+        "dict": {
+            "child": SimpleEventPattern("1")
+        },
+    })
+
+    result = verifier.verify({
+        "name": "Kieran",
+        "dict": {
+            "child": "2"
+        }
+    })
+
+    assert not result
+
+
+def test_event_verifier_expect_event_pattern_group_match():
+    verifier = EventVerifier({
+        "name": SimpleEventPattern("Kieran", 1),
+        "list": [
+            {
+                "child": SimpleEventPattern("1", 1)
+            }
+        ]
+    })
+
+    result = verifier.verify({
+        "name": "Kieran",
+        "list": [
+            {
+                "child": "1"
+            },
+            {
+                "child": "2"
+            }
+        ]
+    })
+
+    assert result
+
+
+def test_event_verifier_expect_event_pattern_group_match_failed():
+    verifier = EventVerifier({
+        "name": SimpleEventPattern("Kieran", 1),
+        "list": [
+            {
+                "child": SimpleEventPattern("1", 1)
+            }
+        ]
+    })
+
+    result = verifier.verify({
+        "name": "Kieran",
+        "list": [
+            {
+                "child": "2"
+            },
+            {
+                "child": "3"
+            }
+        ]
+    })
+
+    assert not result
+
+
+def test_event_verifier_expect_event_pattern_group_match_complex():
+    verifier = EventVerifier({
+        "name": "Kieran",
+        "store": "{{store1,*}}",
+        "list": [
+            {
+                "3": "*",
+                "4": "{{store2,*}}",
+                "5": SimpleEventPattern("V3", "store3", 1),
+                "6": SimpleEventPattern("V4", "store4", 1)
+            },
+            {
+                "6": SimpleEventPattern("V5", "store5")
+            }
+        ],
+        "event_pattern": WildCardEventPattern("V6", 1)
+    })
+
+    result = verifier.verify({
+        "name": "Kieran",
+        "store": "V1",
+        "list": [
+            "1",
+            "2",
+            {
+                "6": "V5"
+            },
+            {
+                "3": {},
+                "4": "V2",
+                "5": 'V3',
+                "6": "V4"
+            }
+        ],
+        "event_pattern": "V6"
+    })
+
+    assert result
+    assert verifier.stored_values["store1"] == "V1"
+    assert verifier.stored_values["store2"] == "V2"
+    assert verifier.stored_values["store3"] == "V3"
+    assert verifier.stored_values["store4"] == "V4"
+    assert verifier.stored_values["store5"] == "V5"
+
+
+def test_event_verifier_expect_event_pattern_group_match_complex_failed():
+    verifier = EventVerifier({
+        "name": "Kieran",
+        "store": "{{store1,*}}",
+        "list": [
+            {
+                "3": "*",
+                "4": "{{store2,*}}",
+                "5": SimpleEventPattern("V3", "store3", 1),
+                "6": SimpleEventPattern("V4", "store4", 1)
+            },
+            {
+                "6": SimpleEventPattern("V5", "store5")
+            }
+        ],
+        "event_pattern": WildCardEventPattern("V6", 1)
+    })
+
+    result = verifier.verify({
+        "name": "Kieran",
+        "store": "V1",
+        "list": [
+            "1",
+            "2",
+            {
+                "6": "V5"
+            },
+            {
+                "3": {},
+                "4": "V2",
+                "5": 'VWRONG',
+                "6": "V4"
+            }
+        ],
+        "event_pattern": "V6"
+    })
+
+    assert not result


### PR DESCRIPTION
Added functionality to allow defining templates for expected events. This avoids needing to create new functions for every type of new matching a user wants to do.

Usage involves the `event_actions.expect_event` function. The function takes a `SlackUser` and a template defining the event. Templates are defined as data structures with the root being a dictionary consisting of any number of child scalar, dictionary, or list values. Matching values can be enforced using two approaches: Simple approach and EventPattern approach.

## Simple Approach
The Simple approach supports 1 to 1 matching, wildcard matching, and matched value storage. The following is an example of such an event template:

```python
{
  "one_to_one": "expected_value",
   "wild_card": "*",
   "stored_value": "{{storage_name,expected_value}}"
}
```

The event template above would match the following event for example:

```python
{
   "one_to_one": "expected_value",
   "wild_card": "any value here",
   "stored_value": "expected_value",
   "any_number_of_other_values_not_in_template": [ ]
}
```

In the above example, the value `"expected_value"` will be stored in the test storage dictionary with a key of "storage_name".

## EventPattern approach
This approach involves using children of the `event_actions.EventPattern` class to match the values. This approach is more powerful as complicated matching functions can be defined (e.g. if regex matching was needed it would use this approach). By default this approach has built in 1 to 1 matching, and wild card matching. These are defined by the children classes `SimpleEventPattern` and `WildCardEventPattern`. These are used in a very similar fashion to the Simple approach definitions.
For example, the equivalent of the Simple Approach example would be:

```python
{
  "one_to_one": SimpleEventPattern("expected_value"),
   "wild_card": WildCardEventPattern(),
   "stored_value": SimpleEventPattern("expected_value", storage_name = "storage_name")
}
```
Additionally, the EventPattern approach brings group matching. That is, the event is only considered matched if the entire group(or all groups) of EventPatterns match successfully. Such a template would be defined for example as follows:

```python
{
   "name": SimpleEventPattern("expected name", group_id = 1),
   "list": [
      {
        "child": SimpleEventPattern("1", group_id = 1, storage_name = "child_value")
      }
   ]
}
```

Such a template would only match/store the value `"child_value"` if the event had a property `list` with a dictionary entry that a `child` property with a value of `"1"`, in addition to root property `name` with a value "expected name". For example, the following event would match successfully:
```python
{
  "name": "expected name",
  "list": [
     {
       "child": "1"
     },
     {
       "child": "not important value"
     }
  ]
}
```
With the `"child_value"` stored being `"1"`. The following event would fail to match on the other hand:
```python
{
  "name": "expected name",
  "list": [
     {
       "child": "a useless value"
     },
     {
       "child": "not important value"
     }
  ]
}
```
Resolves #39 