### PR TITLE
Added a cleanup section to tests

### DIFF
--- a/subatomic_coherence/slack_test_suite.py
+++ b/subatomic_coherence/slack_test_suite.py
@@ -1,14 +1,14 @@
-import logging
 import json
+import logging
+import traceback
 
-import sys
 from colorama import Fore, Style
 
 import subatomic_coherence.ui.ui as UI
-from subatomic_coherence.ui.ui import TestingStage
-from subatomic_coherence.ui.ui import TestStatus
 from subatomic_coherence.logging.console_logging import ConsoleLogger
 from subatomic_coherence.testing.test import ResultCode
+from subatomic_coherence.ui.ui import TestStatus
+from subatomic_coherence.ui.ui import TestingStage
 from subatomic_coherence.user.slack_user import SlackUser
 from subatomic_coherence.user.slack_user_workspace import SlackUserWorkspace
 
@@ -208,7 +208,8 @@ class SlackTestSuite(object):
             try:
                 test.tidy(self.slack_user_workspace)
             except:
-                ConsoleLogger.info("Clean up error ignored: " + sys.exc_info()[0])
+                error_stack_trace = traceback.format_exc()
+                ConsoleLogger.info("Clean up error ignored: " + error_stack_trace)
 
 
 class RecordedEvent(object):

--- a/subatomic_coherence/testing/test.py
+++ b/subatomic_coherence/testing/test.py
@@ -45,6 +45,7 @@ class TestPortal(TestElement):
 
     def set_clean_up(self, clean_up_function):
         self.clean_up = clean_up_function
+        return self
 
     def tidy(self, slack_user_workspace):
         self.clean_up(slack_user_workspace)

--- a/subatomic_coherence/testing/test.py
+++ b/subatomic_coherence/testing/test.py
@@ -16,6 +16,19 @@ class TestElement(object):
         self.start_time = 0
         self.is_started = False
         self.call_stack_message = ""
+        self.parent = None
+
+
+class TestPortal(TestElement):
+    def __init__(self, timeout=15000):
+        super().__init__(self.start_test, timeout)
+        self.current_action = self
+        self.is_live = True
+        self.message = ResultCode.pending.name
+        self.name = "Unnamed Test"
+        self.data_store = {}
+        self.simple_call_stack = []
+        self.clean_up = lambda slack_user_workspace: None
 
     def then(self, next_action, timeout=15000):
         found_leaf_then = False
@@ -30,16 +43,11 @@ class TestElement(object):
 
         return self
 
+    def set_clean_up(self, clean_up_function):
+        self.clean_up = clean_up_function
 
-class TestPortal(TestElement):
-    def __init__(self, timeout=15000):
-        super().__init__(self.start_test, timeout)
-        self.current_action = self
-        self.is_live = True
-        self.message = ResultCode.pending.name
-        self.name = "Unnamed Test"
-        self.data_store = {}
-        self.simple_call_stack = []
+    def tidy(self, slack_user_workspace):
+        self.clean_up(slack_user_workspace)
 
     def test(self, slack_users):
         # noinspection PyBroadException

--- a/testing/tests/test_slack_test_suite.py
+++ b/testing/tests/test_slack_test_suite.py
@@ -137,3 +137,17 @@ def test_update_test_status_with_no_tests_normal_mode_expect_test_status_quit():
     test_suite.test_status.current_operation = TestingStage.run_tests
     test_suite._update_test_status()
     assert test_suite.test_status.current_operation == TestingStage.quit
+
+
+def test_process_current_test_expect_test_passes():
+    test_suite = SlackTestSuite()
+    some_var = 0
+
+    def clean_up(workspace):
+        nonlocal some_var
+        some_var = 2
+
+    test = TestPortal().set_clean_up(clean_up)
+    test_suite.add_test("test", test)
+    test_suite._run_clean_up()
+    assert some_var == 2

--- a/testing/tests/testing/test_test.py
+++ b/testing/tests/testing/test_test.py
@@ -152,3 +152,12 @@ def test_test_portal_push_action_onto_stack_expect_correct_function_name_pushed_
     test = TestPortal().then(some_function)
     test._push_action_onto_stack(test.current_action.next_action)
     assert test.simple_call_stack[0].name == "some_function"
+
+
+def test_test_portal_add_clean_up_function_expect_clean_up_function_created():
+    def some_function(slack_user_workspace):
+        pass
+
+    test = TestPortal().set_clean_up(some_function)
+
+    assert test.clean_up == some_function

--- a/testing/tests/testing/test_test.py
+++ b/testing/tests/testing/test_test.py
@@ -50,20 +50,6 @@ def test_test_portal_test_timeout_expect_failure():
     assert result.message.startswith("Time out occurred when calling") is True
 
 
-def test_test_element_then_expect_next_action_set_correctly():
-    def mock_action1(slack_user_workspace, data_store):
-        return TestResult(ResultCode.success)
-
-    def mock_action2(slack_user_workspace, data_store):
-        return TestResult(ResultCode.failure)
-
-    # this wont actually work but works for test purposes
-    test_element = TestElement(None)
-    test_element.then(mock_action1).then(mock_action2)
-    assert test_element.next_action.run_element == mock_action1
-    assert test_element.next_action.next_action.run_element == mock_action2
-
-
 def test_test_portal_data_store_expect_data_persisted_between_steps():
     def mock_action1(slack_user_workspace, data_store):
         data_store["action1"] = "value1"

--- a/testing/tests/user/test_slack_user_workspace.py
+++ b/testing/tests/user/test_slack_user_workspace.py
@@ -60,6 +60,7 @@ def test_find_channel_by_id_expect_failure():
     channel = slack_user_workspace.find_channel_by_slack_id("channel3")
     assert channel is None
 
+
 def test_find_group_by_name_expect_success():
     slack_user_workspace = SlackUserWorkspace()
     slack_user_workspace.set_workspace_groups([{"name": "group1"}, {"name": "group2"}])


### PR DESCRIPTION
When defining a test chain it is possible to add a clean up function. The goal of the clean up function is primarily to clean the slack workspace but can be used to run anything the user wishes after the test suite has run (probably cleaning up any integration points). This is done by calling the `set_clean_up` function on a TestPortal. The `set_clean_up` function takes a function with one parameter which is a `SlackUserWorkspace` that will be passed to the clean up function by the `SlackTestSuite`. For example:

```python
def clean_up(slack_user_workspace):
  main_user_client = slack_user_workspace.find_user_client_by_username("user_name")
  channel_id = slack_user_workspace.find_channel_by_name("channel_name")["id"]
  main_user_client.delete_channel(channel_id)

TestPortal().then(create_slack_channel).set_clean_up(clean_up)
```
This creates a `TestPortal` which will create some slack channel, then after the entire test suite runs, the created slack channel will be deleted.

Resolves #41 